### PR TITLE
Fix href links

### DIFF
--- a/src/app/(client)/join/page.tsx
+++ b/src/app/(client)/join/page.tsx
@@ -73,7 +73,7 @@ export default function PeepAnEip() {
 
       <div className="flex justify-center w-full pb-16">
         <a
-            href={"https://discord.io/EthCatHerders"}
+            href={"https://dsc.gg/ech"}
             target="_blank"
           >
             <button className="border border-darkGray rounded-lg md:text-2xl text-xl px-4 py-2 hover:text-darkGray text-white hover:bg-white bg-darkGray hover:scale-110 duration-300">

--- a/src/app/(client)/page.tsx
+++ b/src/app/(client)/page.tsx
@@ -72,13 +72,13 @@ export default function Home() {
             <div className="flex sm:flex-row gap-10 items-center">
               <Button
                 text="Join ECH"
-                link="https://docs.google.com/forms/d/1o2Oidzt6qZZ296KkqeNMi6xAALIv8zsBK1Va3Lzc9IQ/viewform?edit_requested=true"
+                link="/join"
                 inverted={true}
                 fontSize={"xl"}
                 size="sm"
               />
               <a
-                href="https://medium.com/ethereum-cat-herders/learn2earn-is-back-with-dencun-nft-3712d2b086fd"
+                href="https://dsc.gg/ech"
                 target="_blank"
                 className="border-b border-dotted pb-1 border-lightGray"
               >

--- a/src/components/hero/page.tsx
+++ b/src/components/hero/page.tsx
@@ -23,8 +23,7 @@ export default function Hero() {
           <div>
             <Button
               text="Join Us"
-              link="https://docs.google.com/forms/d/1o2Oidzt6qZZ296KkqeNMi6xAALIv8zsBK1Va3Lzc9IQ/viewform?edit_requested=true"
-              target="_blank"
+              link="/join"
               size="md"
               fontSize="lg"
             />
@@ -50,13 +49,13 @@ export default function Hero() {
       <div className="w-100wh flex flex-wrap justify-center md:gap-5 spacey-y-2 p-4 gap-2">
         <Button
           text="Dencun"
-          link="/network_upgrades/dencun"
+          link="/upgrades/dencun"
           size="md"
           fontSize="lg"
         />
         <Button
           text="Pectra"
-          link="/network_upgrades/pectra"
+          link="/upgrades/pectra"
           size="md"
           fontSize="lg"
         />


### PR DESCRIPTION
Fixed the following links:
1. Replaced broken discord links in homepage and /join page
2. Fixed upgrade links in hero section from `/network_upgrades/[NAME]` to `/upgrades/[NAME]`
3. Replaced onboarding google form link with `/join` page link in Join Us buttons on homepage