### PR TITLE
Add videos of Devcon Bangkok recap and speaker talks

### DIFF
--- a/src/app/(client)/events/page.tsx
+++ b/src/app/(client)/events/page.tsx
@@ -32,64 +32,72 @@ export default function Events() {
             DEVCON Bangkok 2024
           </h1>
           <p className="text-lg">Endgame for Ethereum’s Infinite Garden</p>
+          <div className="flex flex-col w-full justify-center items-center space-y-6 py-6">
+            <div className="box-black-bg rounded-xl h-[8rem] max-w-lg w-full flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
+              <p className="text-md">An Overview of Women in Ethereum Protocol (WiEP)</p>
+              <p className="text-sm font-normal">La Donna Higgins and Pooja Ranjan</p>
+              <Link href="https://youtu.be/idMUzYquvB8?si=hHZx73gH_hJHW9WR" className="text-center text-sm font-normal" target="_blank" passHref>
+                <div className="flex items-center gap-1">
+                  <p>Watch video</p>
+                  <CgExternal />
+                </div>
+              </Link>
+            </div>
+            <div className="box-black-bg rounded-xl h-[8rem] max-w-lg w-full flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
+              <p className="text-md">Shaping Ethereum's Protocol Governance & Decision Making</p>
+              <p className="text-sm font-normal">Pooja Ranjan</p>
+              <Link href="https://youtu.be/U_UN8FRqi5c" className="text-center text-sm font-normal" target="_blank" passHref>
+                <div className="flex items-center gap-1">
+                  <p>Watch video</p>
+                  <CgExternal />
+                </div>
+              </Link>
+            </div>
+          </div>
         </div>
 
         <div className="flex flex-col justify-start max-w-xl space-y-6">
           <p className="text-lg text-lightGray text-justify">
-            The ETH Cat Herders are heading to Devcon in Bangkok next month! We can’t wait to connect with the Ethereum community, share our resources, and learn from the amazing builders, researchers, and innovators attending.
+            The ETH Cat Herders headed to Devcon in Bangkok in November! Watch the videos of our recap and talks.
           </p>
-          <p className="text-lg text-lightGray text-justify">
-            Visit us at our booth for some exclusive merch! For more information, check out our location here:{" "}
-            <a
-              href="https://lu.ma/2q0wpfe4"
-              target="_blank"
-            >
-              <span className="border-b border-dotted pb-1 border-lightGray">
-                lu.ma
-              </span>
-            </a>.
-          </p>
-        </div>
-      </div>
-      <div className="flex flex-col w-full justify-center items-center">
-        <div className="box-black-bg rounded-xl h-[10rem] max-w-lg w-full flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
-          <p className="text-center text-md">Hangout with Ethereum Cat Herders!</p>
-          <p className="text-center text-sm font-normal">November 12th, 8:30 AM - Nov 13, 8:00 PM</p>
-          <Link href="https://lu.ma/2q0wpfe4" className="text-center text-sm font-normal" target="_blank" passHref>
-            <div className="flex items-center justify-center gap-1">
-              <p>Details</p>
-              <CgExternal />
-            </div>
-          </Link>
+          <iframe 
+            width="560" 
+            height="315" 
+            src="https://www.youtube.com/embed/rksdvA4oHWU?si=kIxeIr9ArlHmUkkG" 
+            title="YouTube video player" 
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+            referrerPolicy="strict-origin-when-cross-origin" 
+            allowFullScreen 
+          />
         </div>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 sm:grid-cols-1 gap-5 items-center justify-evenly">
-        <div className="box-black-bg rounded-xl h-[10rem] flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
-          <p className="text-center text-md">EIPs Simplified: History and Process Explained</p>
-          <p className="text-center text-sm font-normal">November 12th, 12:30pm</p>
-          <Link href="https://x.com/EFDevcon/status/1831644714958778694" className="text-center text-sm font-normal" target="_blank" passHref>
-            <div className="flex items-center justify-center gap-1">
-              <p>Details</p>
+        <div className="box-black-bg rounded-xl h-[8rem] max-w-lg w-full flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
+          <p className="text-md">WiEP Introduction | W3 Hub</p>
+          <p className="text-sm font-normal">La Donna Higgins and Pooja Ranjan</p>
+          <Link href="https://youtu.be/C_zkU-f4tto" className="text-center text-sm font-normal" target="_blank" passHref>
+            <div className="flex items-center gap-1">
+              <p>Watch video</p>
               <CgExternal />
             </div>
           </Link>
         </div>
-        <div className="box-black-bg rounded-xl h-[10rem] flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
-          <p className="text-center text-md">WiEP Brunch & Networking</p>
-          <p className="text-center text-sm font-normal">November 14th</p>
-          <Link href="https://lu.ma/b2bdsuke?tk=a4jeK5" className="text-center text-sm font-normal" target="_blank" passHref>
-            <div className="flex items-center justify-center gap-1">
-              <p>Details</p>
+        <div className="box-black-bg rounded-xl h-[8rem] max-w-lg w-full flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
+          <p className="text-md">Sandra Johnson's Journey</p>
+          <p className="text-sm font-normal">Sandra Johnson</p>
+          <Link href="https://youtu.be/wQ2RqrAFxG8?si=-vNfyhe8jNbJnVm4" className="text-center text-sm font-normal" target="_blank" passHref>
+            <div className="flex items-center gap-1">
+              <p>Watch video</p>
               <CgExternal />
             </div>
           </Link>
         </div>
-        <div className="box-black-bg rounded-xl h-[10rem] flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
-          <p className="text-center text-md">Shaping Ethereum Protocol Governance and Decision Making</p>
-          <p className="text-center text-sm font-normal">November 14th, 2:00 - 2:15pm</p>
-          <Link href="https://lu.ma/13y7x8sn" className="text-center text-sm font-normal" passHref>
-            <div className="flex items-center justify-center gap-1">
-              <p>Details</p>
+        <div className="box-black-bg rounded-xl h-[8rem] max-w-lg w-full flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
+          <p className="text-md">WEiP Study Group: Insights from Gyan & Lena</p>
+          <p className="text-sm font-normal">Gyan & Lena</p>
+          <Link href="https://youtu.be/5gWbu8lbFMA" className="text-center text-sm font-normal" target="_blank" passHref>
+            <div className="flex items-center gap-1">
+              <p>Watch video</p>
               <CgExternal />
             </div>
           </Link>
@@ -116,20 +124,6 @@ export default function Events() {
             referrerPolicy="strict-origin-when-cross-origin" 
             allowFullScreen 
           />
-          {/* <p className="text-lg text-lightGray text-justify">
-            The ETH Cat Herders are heading to Devcon in Bangkok next month! We can’t wait to connect with the Ethereum community, share our resources, and learn from the amazing builders, researchers, and innovators attending.
-          </p>
-          <p className="text-lg text-lightGray text-justify">
-            Visit us at our booth for some exclusive merch! For more information, check out our location here:{" "}
-            <a
-              href="https://lu.ma"
-              target="_blank"
-            >
-              <span className="border-b border-dotted pb-1 border-lightGray">
-                lu.ma
-              </span>
-            </a>.
-          </p> */}
         </div>
       </div>
     </PageContainer>

--- a/src/app/(client)/events/page.tsx
+++ b/src/app/(client)/events/page.tsx
@@ -44,7 +44,7 @@ export default function Events() {
               </Link>
             </div>
             <div className="box-black-bg rounded-xl h-[8rem] max-w-lg w-full flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
-              <p className="text-md">Shaping Ethereum's Protocol Governance & Decision Making</p>
+              <p className="text-md">Shaping Ethereum’s Protocol Governance & Decision Making</p>
               <p className="text-sm font-normal">Pooja Ranjan</p>
               <Link href="https://youtu.be/U_UN8FRqi5c" className="text-center text-sm font-normal" target="_blank" passHref>
                 <div className="flex items-center gap-1">
@@ -83,7 +83,7 @@ export default function Events() {
           </Link>
         </div>
         <div className="box-black-bg rounded-xl h-[8rem] max-w-lg w-full flex md:p-6 p-3 flex-col font-bold justify-between text-darkGray border-2 border-black">
-          <p className="text-md">Sandra Johnson's Journey</p>
+          <p className="text-md">Sandra Johnson’s Journey</p>
           <p className="text-sm font-normal">Sandra Johnson</p>
           <Link href="https://youtu.be/wQ2RqrAFxG8?si=-vNfyhe8jNbJnVm4" className="text-center text-sm font-normal" target="_blank" passHref>
             <div className="flex items-center gap-1">


### PR DESCRIPTION
Replaced the event details links with the YouTube recordings of the talks done by ECH at Devcon 2024. Also changed the layout of the Devcon section in the events page to include an iframe of the recap video.