### PR TITLE
fix(client/api): treat github usernames as case insensitive

### DIFF
--- a/src/app/(client)/api/eip-author/[upgrade]/[username]/route.ts
+++ b/src/app/(client)/api/eip-author/[upgrade]/[username]/route.ts
@@ -1,4 +1,4 @@
-import { hasAlreadyClaimed } from "@/components/nft-claim/utils";
+import { hasAlreadyClaimed, findEipAuthorByGithubUsername } from "@/components/nft-claim/utils";
 import { NetworkUpgrade, eipAuthorsByUpgrade } from "@/constants/eip-authors";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -8,7 +8,7 @@ export async function GET(
 ) {
   const { upgrade, username } = params;
   const eipAuthors = eipAuthorsByUpgrade[upgrade];
-  const author = eipAuthors.find((author) => author.github === `https://github.com/${username}`);
+  const author = findEipAuthorByGithubUsername(eipAuthors, username);
   if (!author) {
     return NextResponse.json({ author, hasClaimed: false });
   }

--- a/src/app/(client)/api/eip-author/[upgrade]/claim-nft/route.ts
+++ b/src/app/(client)/api/eip-author/[upgrade]/claim-nft/route.ts
@@ -1,4 +1,4 @@
-import { chainId, eipAuthorNftAddress, getChain, getTokenIdOfUpgrade, hasAlreadyClaimed } from "@/components/nft-claim/utils";
+import { chainId, eipAuthorNftAddress, getChain, getTokenIdOfUpgrade, hasAlreadyClaimed, findEipAuthorByGithubUsername } from "@/components/nft-claim/utils";
 import { eipAuthorsByUpgrade, NetworkUpgrade } from "@/constants/eip-authors";
 import { NextRequest, NextResponse } from "next/server";
 import { http, isAddress, parseAbi, createWalletClient } from "viem";
@@ -9,7 +9,7 @@ export async function POST(req: NextRequest, { params }: { params: { upgrade: Ne
   const upgrade = params.upgrade;
 
   const eipAuthors = eipAuthorsByUpgrade[upgrade];
-  const author = eipAuthors.find((author) => author.github === `https://github.com/${githubUsername}`);
+  const author = findEipAuthorByGithubUsername(eipAuthors, githubUsername);
   if (!author) {
     return NextResponse.json({ error: "Not an EIP author" }, { status: 400 })
   }

--- a/src/components/nft-claim/utils.ts
+++ b/src/components/nft-claim/utils.ts
@@ -9,7 +9,7 @@ import {
   Chain,
 } from "viem";
 import { base, baseSepolia, foundry, optimism, optimismSepolia } from "viem/chains"
-import { NetworkUpgrade } from "@/constants/eip-authors";
+import { EipAuthor, NetworkUpgrade } from "@/constants/eip-authors";
 
 export const chainId = Number(process.env.NEXT_PUBLIC_CHAIN_ID || process.env.CHAIN_ID)
 
@@ -51,4 +51,10 @@ export async function hasAlreadyClaimed(githubUsername: string, upgrade: Network
     console.error(error)
     return false
   }
+}
+
+// Find an EIP author with case-insensitive GitHub username matching
+export function findEipAuthorByGithubUsername(authors: EipAuthor[], username: string) {
+  const githubUrl = `https://github.com/${username}`.toLowerCase();
+  return authors.find(author => author.github.toLowerCase() === githubUrl);
 }


### PR DESCRIPTION
Unfortunately i have a capital in my github username but the one in the EIP is lowercase, so when I try to claim the upgrade NFT's directly from the website it won't match.

Direct API test;

```bash
# My actual github username with uppercase S
curl https://www.ethcatherders.com/api/eip-author/pectra/Savid
{"hasClaimed":false}

# My EIP github handle with lowercase s
curl https://www.ethcatherders.com/api/eip-author/pectra/savid
{"author":{"github":"https://github.com/savid","eips":["7691"]},"hasClaimed":false}
```

Github usernames can be treated as case insensitive, this PR just updates the EIP author check to handle this