### PR TITLE
Fix: remove dashes and improper capitalization of upgrade name

### DIFF
--- a/src/app/(client)/upgrades/[upgrade_name]/page.tsx
+++ b/src/app/(client)/upgrades/[upgrade_name]/page.tsx
@@ -30,6 +30,13 @@ export default function NetworkUpgradePage() {
     fetchData();
   }, [upgradeName]);
 
+  const upgradeTitle = upgradeName.split("-").map(word => {
+    if (word === "dao") {
+      return "DAO";
+    }
+    return word.charAt(0).toUpperCase() + word.slice(1)
+  }).join(" ");
+
   if (!data && upgradeName !== "the-merge") {
     return (
       <>
@@ -63,13 +70,10 @@ export default function NetworkUpgradePage() {
             <div className="flex flex-col gap-y-6 xl:max-w-xl md:max-w-2xl">
               <section className="flex flex-col gap-y-4 ">
                 <h1 className="xl:text-6xl lg:text-4xl sm:text-4xl text-3xl font-roboto font-bold text-darkGray">
-                  {upgradeName.charAt(0).toUpperCase() + upgradeName.slice(1)}{" "}
-                  Upgrade
+                  {upgradeTitle} Upgrade
                 </h1>
                 <h3 className="text-darkGray font-roboto font-medium xl:text-2xl md:text-xl text-lg">
-                  What is the{" "}
-                  {upgradeName.charAt(0).toUpperCase() + upgradeName.slice(1)}{" "}
-                  Upgrade?
+                  What is the {upgradeTitle} Upgrade?
                 </h3>
               </section>
               <section>
@@ -124,9 +128,7 @@ export default function NetworkUpgradePage() {
             <div className="flex justify-center text-center mx-5">
               <span className="md:text-3xl text-xl text-center font-roboto font-bold">
                 In the section below you can find more resources providing
-                information on the{" "}
-                {upgradeName.charAt(0).toUpperCase() + upgradeName.slice(1)}{" "}
-                Upgrade.
+                information on the {upgradeTitle} Upgrade.
               </span>
             </div>
           ) : null}


### PR DESCRIPTION
Some Ethereum upgrades contain more than 1 word or an acronym, which the logic to parse the pathname and render in the Upgrade page did not account for. Fixed that so those names don't look weird in the UI anymore.